### PR TITLE
Support for Swift 3.0 and Xcode 8

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -394,6 +394,17 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					408701E9604E47D80110B32F1A3017E2 = {
+						LastSwiftMigration = 0800;
+					};
+					92303C95FF31137101581B1E2E435A5C = {
+						LastSwiftMigration = 0800;
+					};
+					C247E74BE69D3289C8DBE3A5123898F6 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -555,6 +566,7 @@
 				PRODUCT_NAME = Scale;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -598,6 +610,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -628,6 +641,7 @@
 				PRODUCT_NAME = Pods_Scale_Tests;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -698,6 +712,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -728,6 +743,7 @@
 				PRODUCT_NAME = Pods_Scale_Example;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -756,6 +772,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Scale.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Scale.xcscheme
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'DEEDBFCE7F991481658B57B6'
-               BlueprintName = 'Scale'
-               ReferencedContainer = 'container:Pods.xcodeproj'
-               BuildableName = 'Scale.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C247E74BE69D3289C8DBE3A5123898F6"
+               BuildableName = "Scale.framework"
+               BlueprintName = "Scale"
+               ReferencedContainer = "container:Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -38,17 +41,25 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C247E74BE69D3289C8DBE3A5123898F6"
+            BuildableName = "Scale.framework"
+            BlueprintName = "Scale"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Scale.xcodeproj/project.pbxproj
+++ b/Example/Scale.xcodeproj/project.pbxproj
@@ -210,14 +210,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Fantageek;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -488,12 +490,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4CE5727A23D8C7A9B899D0D4 /* Pods-Scale_Example.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Scale/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -501,12 +505,15 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1B1803ED2C3CE98431123BA2 /* Pods-Scale_Example.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Scale/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -514,11 +521,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0DE67CDF2219C57C0944D13E /* Pods-Scale_Tests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -527,6 +531,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Scale_Example.app/Scale_Example";
 			};
 			name = Debug;
@@ -535,15 +540,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7F039A4ADDE09AD73CB4D88F /* Pods-Scale_Tests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Scale_Example.app/Scale_Example";
 			};
 			name = Release;

--- a/Example/Scale.xcodeproj/xcshareddata/xcschemes/Scale-Example.xcscheme
+++ b/Example/Scale.xcodeproj/xcshareddata/xcschemes/Scale-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Scale/AppDelegate.swift
+++ b/Example/Scale/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Pod/Classes/Output/Angle.swift
+++ b/Pod/Classes/Output/Angle.swift
@@ -27,7 +27,7 @@ public struct Angle {
         self.unit = unit
     }
 
-    public func to(unit unit: AngleUnit) -> Angle {
+    public func to(unit: AngleUnit) -> Angle {
         return Angle(value: self.value * self.unit.rawValue * AngleUnit.degree.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -46,7 +46,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Angle, right: Angle, operation: (Double, Double) -> Double) -> Angle {
+public func compute(_ left: Angle, right: Angle, operation: (Double, Double) -> Double) -> Angle {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -67,7 +67,7 @@ public func *(left: Angle, right: Angle) -> Angle {
 
 public func /(left: Angle, right: Angle) throws -> Angle {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Area.swift
+++ b/Pod/Classes/Output/Area.swift
@@ -31,7 +31,7 @@ public struct Area {
         self.unit = unit
     }
 
-    public func to(unit unit: AreaUnit) -> Area {
+    public func to(unit: AreaUnit) -> Area {
         return Area(value: self.value * self.unit.rawValue * AreaUnit.squareMeter.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -66,7 +66,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Area, right: Area, operation: (Double, Double) -> Double) -> Area {
+public func compute(_ left: Area, right: Area, operation: (Double, Double) -> Double) -> Area {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -87,7 +87,7 @@ public func *(left: Area, right: Area) -> Area {
 
 public func /(left: Area, right: Area) throws -> Area {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Energy.swift
+++ b/Pod/Classes/Output/Energy.swift
@@ -29,7 +29,7 @@ public struct Energy {
         self.unit = unit
     }
 
-    public func to(unit unit: EnergyUnit) -> Energy {
+    public func to(unit: EnergyUnit) -> Energy {
         return Energy(value: self.value * self.unit.rawValue * EnergyUnit.joule.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -56,7 +56,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Energy, right: Energy, operation: (Double, Double) -> Double) -> Energy {
+public func compute(_ left: Energy, right: Energy, operation: (Double, Double) -> Double) -> Energy {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -77,7 +77,7 @@ public func *(left: Energy, right: Energy) -> Energy {
 
 public func /(left: Energy, right: Energy) throws -> Energy {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Error.swift
+++ b/Pod/Classes/Output/Error.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-enum Error: ErrorType {
-    case DividedByZero
+enum Error: ErrorProtocol {
+    case dividedByZero
 }

--- a/Pod/Classes/Output/Length.swift
+++ b/Pod/Classes/Output/Length.swift
@@ -38,7 +38,7 @@ public struct Length {
         self.unit = unit
     }
 
-    public func to(unit unit: LengthUnit) -> Length {
+    public func to(unit: LengthUnit) -> Length {
         return Length(value: self.value * self.unit.rawValue * LengthUnit.meter.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -101,7 +101,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Length, right: Length, operation: (Double, Double) -> Double) -> Length {
+public func compute(_ left: Length, right: Length, operation: (Double, Double) -> Double) -> Length {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -122,7 +122,7 @@ public func *(left: Length, right: Length) -> Length {
 
 public func /(left: Length, right: Length) throws -> Length {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Metric.swift
+++ b/Pod/Classes/Output/Metric.swift
@@ -37,7 +37,7 @@ public struct Metric {
         self.unit = unit
     }
 
-    public func to(unit unit: MetricUnit) -> Metric {
+    public func to(unit: MetricUnit) -> Metric {
         return Metric(value: self.value * self.unit.rawValue * MetricUnit.base.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -96,7 +96,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Metric, right: Metric, operation: (Double, Double) -> Double) -> Metric {
+public func compute(_ left: Metric, right: Metric, operation: (Double, Double) -> Double) -> Metric {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -117,7 +117,7 @@ public func *(left: Metric, right: Metric) -> Metric {
 
 public func /(left: Metric, right: Metric) throws -> Metric {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Power.swift
+++ b/Pod/Classes/Output/Power.swift
@@ -30,7 +30,7 @@ public struct Power {
         self.unit = unit
     }
 
-    public func to(unit unit: PowerUnit) -> Power {
+    public func to(unit: PowerUnit) -> Power {
         return Power(value: self.value * self.unit.rawValue * PowerUnit.watt.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -61,7 +61,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Power, right: Power, operation: (Double, Double) -> Double) -> Power {
+public func compute(_ left: Power, right: Power, operation: (Double, Double) -> Double) -> Power {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -82,7 +82,7 @@ public func *(left: Power, right: Power) -> Power {
 
 public func /(left: Power, right: Power) throws -> Power {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Temperature.swift
+++ b/Pod/Classes/Output/Temperature.swift
@@ -27,7 +27,7 @@ public struct Temperature {
         self.unit = unit
     }
 
-    public func to(unit unit: TemperatureUnit) -> Temperature {
+    public func to(unit: TemperatureUnit) -> Temperature {
         switch (self.unit, unit) {
         case (.celsius, .fahrenheit):
             return Temperature(value: self.value * 1.8 + 32, unit: unit)
@@ -61,7 +61,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Temperature, right: Temperature, operation: (Double, Double) -> Double) -> Temperature {
+public func compute(_ left: Temperature, right: Temperature, operation: (Double, Double) -> Double) -> Temperature {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -82,7 +82,7 @@ public func *(left: Temperature, right: Temperature) -> Temperature {
 
 public func /(left: Temperature, right: Temperature) throws -> Temperature {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Time.swift
+++ b/Pod/Classes/Output/Time.swift
@@ -39,7 +39,7 @@ public struct Time {
         self.unit = unit
     }
 
-    public func to(unit unit: TimeUnit) -> Time {
+    public func to(unit: TimeUnit) -> Time {
         return Time(value: self.value * self.unit.rawValue * TimeUnit.second.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -106,7 +106,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Time, right: Time, operation: (Double, Double) -> Double) -> Time {
+public func compute(_ left: Time, right: Time, operation: (Double, Double) -> Double) -> Time {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -127,7 +127,7 @@ public func *(left: Time, right: Time) -> Time {
 
 public func /(left: Time, right: Time) throws -> Time {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Volume.swift
+++ b/Pod/Classes/Output/Volume.swift
@@ -35,7 +35,7 @@ public struct Volume {
         self.unit = unit
     }
 
-    public func to(unit unit: VolumeUnit) -> Volume {
+    public func to(unit: VolumeUnit) -> Volume {
         return Volume(value: self.value * self.unit.rawValue * VolumeUnit.liter.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -86,7 +86,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Volume, right: Volume, operation: (Double, Double) -> Double) -> Volume {
+public func compute(_ left: Volume, right: Volume, operation: (Double, Double) -> Double) -> Volume {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -107,7 +107,7 @@ public func *(left: Volume, right: Volume) -> Volume {
 
 public func /(left: Volume, right: Volume) throws -> Volume {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)

--- a/Pod/Classes/Output/Weight.swift
+++ b/Pod/Classes/Output/Weight.swift
@@ -37,7 +37,7 @@ public struct Weight {
         self.unit = unit
     }
 
-    public func to(unit unit: WeightUnit) -> Weight {
+    public func to(unit: WeightUnit) -> Weight {
         return Weight(value: self.value * self.unit.rawValue * WeightUnit.gram.rawValue / unit.rawValue, unit: unit)
     }
 }
@@ -96,7 +96,7 @@ public extension Double {
     }
 }
 
-public func compute(left: Weight, right: Weight, operation: (Double, Double) -> Double) -> Weight {
+public func compute(_ left: Weight, right: Weight, operation: (Double, Double) -> Double) -> Weight {
     let (min, max) = left.unit.rawValue < right.unit.rawValue ? (left, right) : (right, left)
     let result = operation(min.value, max.to(unit: min.unit).value)
 
@@ -117,7 +117,7 @@ public func *(left: Weight, right: Weight) -> Weight {
 
 public func /(left: Weight, right: Weight) throws -> Weight {
     guard right.value != 0 else {
-        throw Error.DividedByZero
+        throw Error.dividedByZero
     }
 
     return compute(left, right: right, operation: /)


### PR DESCRIPTION
Used the migration assistant to convert to Swift 3.0. Compiled without errors or warnings using Xcode 8b3.
